### PR TITLE
Document dataset source and add data loading test

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,23 @@ In the digital age, the proliferation of fake news is a significant challenge. O
 The dataset contains labeled news articles, categorized as either true (authentic) or false (fake). The data is divided into two categories:
 - **True**: Legitimate news articles.
 - **False**: Fake or fabricated news articles.
+### Data Source and License
+The CSV files in the `datasets/` directory originate from the
+[**Fake and Real News Dataset**](https://www.kaggle.com/clmentbisaillon/fake-and-real-news-dataset)
+available on Kaggle. The dataset is distributed under the
+[**CC0 1.0 license**](https://creativecommons.org/publicdomain/zero/1.0/), so
+these files may be freely copied or modified. The repository includes the
+original `Fake.csv` and `True.csv` files from Kaggle, renamed here as
+`FakeNewsData.csv` and `TrueNewsData.csv`.
 
-### Data Preprocessing:
-- Cleaned and normalized text data.
-- Used techniques like tokenization and vectorization (TF-IDF) to prepare the dataset for model training.
+The dataset contains **23,481** fake news entries and **21,417** real news
+entries. No rows or columns were removed when copying the data into this
+repository.
+
+### Data Preprocessing
+- Dropped the `title`, `subject`, and `date` columns from the original files.
+- Removed punctuation, lowercased the text and stripped HTML artifacts.
+- Filtered out common stop words, tokenized articles and applied TF-IDF vectorization for model training.
 
 ## Dependencies
 
@@ -34,12 +47,11 @@ Make sure the following Python libraries are installed before running the projec
 - NumPy
 - Seaborn
 - Matplotlib
-- Regular Expression (re)
 
 Install these dependencies using pip:
 
 ```bash
-pip install pandas numpy matplotlib sklearn seaborn re
+pip install -r requirements.txt
 ```
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pandas
+numpy
+matplotlib
+scikit-learn
+seaborn
+pytest

--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -1,0 +1,13 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from main import load_datasets
+
+def test_load_datasets():
+    data_dir = os.path.join(os.path.dirname(__file__), '..', 'datasets')
+    data_dir = os.path.abspath(data_dir)
+    data = load_datasets(data_dir)
+    assert 'text' in data.columns
+    assert 'class' in data.columns
+    assert len(data[data['class'] == 0]) == 23481
+    assert len(data[data['class'] == 1]) == 21417


### PR DESCRIPTION
## Summary
- mention Kaggle dataset origin and CC0 license in README
- detail preprocessing steps
- add basic data loading unit test
- include pytest in requirements

## Testing
- `pytest -q`
- `python main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_683f641b848c832fb5dace7450059def